### PR TITLE
Allow to overwrite and extend the core components

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,12 @@ export interface HasAttributes {
     attrs?: Object;
 }
 
+export interface AllowsExtends {
+    extend?: {
+        [key: string]: Function;
+    };
+}
+
 export interface HasChildren {
     children: React.ReactNode;
 }
@@ -58,10 +64,10 @@ export const HardBreak = () => {
     return (<br />)
 };
 
-export const Heading = ({ attrs, content = [], sets }: HasContent & HasSets & HeadingAttributes) => {
+export const Heading = ({ attrs, content = [], sets, extend }: HasContent & HasSets & AllowsExtends & HeadingAttributes) => {
     const Tag = `h${attrs.level}` as keyof JSX.IntrinsicElements;
 
-    return (<Tag><Bard data={content} sets={sets} /></Tag>);
+    return (<Tag><Bard data={content} sets={sets} extend={extend} /></Tag>);
 };
 
 export const HorizontalRule = () => {
@@ -72,7 +78,7 @@ export const Markup = ({ type, attrs, children }: HasType & HasAttributes & HasC
     return (<Tag type={type} {...attrs} >{children}</Tag>) ;
 }
 
-export const Set = ({ attrs, sets }:SetAttributes & HasSets) => {
+export const Set = ({ attrs, sets }:SetAttributes & HasSets & AllowsExtends) => {
     const { values } = attrs; 
     const Component = sets[values.type];
     return (<Component {...values} />);
@@ -88,11 +94,11 @@ export const Text = ({ marks = [], text }: {marks: Array<HasType & HasAttributes
     return output;
 }
 
-export const Utility = ({ content = [], type, sets }:HasType & HasContent & HasSets) => {
-    return (<Tag type={type}><Bard data={content} sets={sets} /></Tag>);
+export const Utility = ({ content = [], type, sets, extend }:HasType & HasContent & HasSets & AllowsExtends) => {
+    return (<Tag type={type}><Bard data={content} sets={sets} extend={extend} /></Tag>);
 };
 
-const Bard = ({ data, sets }: { data: Array<HasType> } & HasSets ) => {
+const Bard = ({ data, sets, extend = {} }: { data: Array<HasType> } & HasSets & AllowsExtends) => {
     const components = {
         heading: Heading,
         horizontal_rule: HorizontalRule,
@@ -102,7 +108,7 @@ const Bard = ({ data, sets }: { data: Array<HasType> } & HasSets ) => {
     }
     
     return data.map((item) => {
-        const Component = components[item.type] || Utility;
+        const Component = extend[item.type] || components[item.type] || Utility;
         const key = Math.random().toString(36).substr(2, 8);
 
         return (<Component {...item} sets={ sets } key={key} />);

--- a/tests/Bard.test.js
+++ b/tests/Bard.test.js
@@ -63,13 +63,13 @@ describe("Bard", () => {
         ]);
     });
 
-    test("it allows to overwrite components", () => {
+    test("it allows extensions and to overwrite components", () => {
         const data = [{ type: "paragraph" }];
 
         const overrides = { "paragraph": MyParagraph };
 
         const results = TestRenderer.create(
-            <Bard data={data} overrides={overrides} />
+            <Bard data={data} extend={overrides} />
         ).toTree().rendered;
 
         expect(results.type).toBe(MyParagraph);

--- a/tests/Bard.test.js
+++ b/tests/Bard.test.js
@@ -8,6 +8,7 @@ import Bard, {
     Text,
     Utility,
 } from "../src/index";
+import MyParagraph from "./stubs/MyParagraph";
 import MySet from "./stubs/MySet";
 
 describe("Bard", () => {
@@ -60,6 +61,18 @@ describe("Bard", () => {
             Heading,
             Text,
         ]);
+    });
+
+    test("it allows to overwrite components", () => {
+        const data = [{ type: "paragraph" }];
+
+        const overrides = { "paragraph": MyParagraph };
+
+        const results = TestRenderer.create(
+            <Bard data={data} overrides={overrides} />
+        ).toTree().rendered;
+
+        expect(results.type).toBe(MyParagraph);
     });
     
 });

--- a/tests/stubs/MyParagraph.js
+++ b/tests/stubs/MyParagraph.js
@@ -1,0 +1,3 @@
+const MyParagraph = (values) => null;
+
+export default MyParagraph;


### PR DESCRIPTION
This PR adds the functionality to override or extend to the core components.

```js
const overrides = {
    paragraph: MyParagraph
};

<Bard data={data} extend={overrides} />
```

:bowtie: 